### PR TITLE
feat: [ENG-63] dark theme for bulk-email editor surface

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,10 @@ and this project adheres to customized Semantic Versioning e.g.: `teak-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* Sync the bulk-email TinyMCE editor surface with the live dark ``theme-variant`` cookie (ENG-63)
+
 [release/teak-rg.3] - 2026-02-27
 ********************************
 

--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -50,9 +50,9 @@ function isDarkThemeActive() {
 }
 
 function applyEditorTheme(editor) {
-  if (!editor || editor.removed) return;
+  if (!editor || editor.removed) { return; }
   const doc = editor.getDoc && editor.getDoc();
-  if (!doc || !doc.head) return;
+  if (!doc || !doc.head) { return; }
   let styleEl = doc.getElementById('rg-dark-content');
   if (isDarkThemeActive()) {
     if (!styleEl) {
@@ -60,7 +60,7 @@ function applyEditorTheme(editor) {
       styleEl.id = 'rg-dark-content';
       doc.head.appendChild(styleEl);
     }
-    if (styleEl.textContent !== DARK_CONTENT_CSS) styleEl.textContent = DARK_CONTENT_CSS;
+    if (styleEl.textContent !== DARK_CONTENT_CSS) { styleEl.textContent = DARK_CONTENT_CSS; }
   } else if (styleEl) {
     styleEl.remove();
   }
@@ -79,7 +79,7 @@ export default function TextEditor(props) {
   useEffect(() => {
     const sync = () => applyEditorTheme(editorRef.current);
     const intervalId = setInterval(sync, 1000);
-    const onMessage = (e) => { if (e && e.data && e.data.type === 'rg-theme-variant') sync(); };
+    const onMessage = (e) => { if (e && e.data && e.data.type === 'rg-theme-variant') { sync(); } };
     window.addEventListener('message', onMessage);
     return () => { clearInterval(intervalId); window.removeEventListener('message', onMessage); };
   }, []);

--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Editor } from '@tinymce/tinymce-react';
 import PropTypes from 'prop-types';
 import 'tinymce';
@@ -20,10 +20,69 @@ import '@edx/tinymce-language-selector';
 import contentUiCss from 'tinymce/skins/ui/oxide/content.css';
 import contentCss from 'tinymce/skins/content/default/content.css';
 
+// The editor writing surface is a same-origin <iframe> that loads ONLY `content_style`
+// (never the page's dark Paragon variant), so by default it renders black text on the
+// (theme-darkened) iframe element = unreadable in dark. We can't bake this into
+// `content_style` reliably here: (a) `content_style` is read ONCE at editor init, so it
+// can't follow a theme toggle that happens after the editor mounts (or activation by the
+// link-flip with no header toggle on this MFE); and (b) `contentUiCss`/`contentCss`
+// stringify to "[object Object]" in this build, so appending rules to `content_style`
+// is fragile (an invalid stray prelude silently drops the first rule). Instead, manage a
+// dedicated <style id="rg-dark-content"> inside the editor iframe LIVE — add it when the
+// `theme-variant=dark` cookie is set, remove it otherwise — so it works regardless of
+// activation timing and switches both ways. (Mirrors authoring TinyMceWidget /
+// discussions TinyMCEEditor, but reactive rather than init-only.)
+const DARK_CONTENT_CSS = `
+  body, body.mce-content-body {
+    background-color: #212529 !important;
+    color: #e8e8e8 !important;
+  }
+  body a { color: #6ccb6c !important; }
+  body blockquote { border-left-color: #5c5c5c !important; color: #e8e8e8 !important; }
+  body code { background-color: rgba(255, 255, 255, 0.08) !important; color: #f48fb1 !important; }
+  body th, body td { border-color: #5c5c5c !important; }
+  body hr { border-color: #5c5c5c !important; }
+`;
+
+function isDarkThemeActive() {
+  return typeof document !== 'undefined'
+    && /(?:^|;)\s*theme-variant=dark(?:;|$)/.test(document.cookie || '');
+}
+
+function applyEditorTheme(editor) {
+  if (!editor || editor.removed) return;
+  const doc = editor.getDoc && editor.getDoc();
+  if (!doc || !doc.head) return;
+  let styleEl = doc.getElementById('rg-dark-content');
+  if (isDarkThemeActive()) {
+    if (!styleEl) {
+      styleEl = doc.createElement('style');
+      styleEl.id = 'rg-dark-content';
+      doc.head.appendChild(styleEl);
+    }
+    if (styleEl.textContent !== DARK_CONTENT_CSS) styleEl.textContent = DARK_CONTENT_CSS;
+  } else if (styleEl) {
+    styleEl.remove();
+  }
+}
+
 export default function TextEditor(props) {
   const {
     onChange, onKeyUp, onInit, disabled, value,
   } = props;
+
+  const editorRef = useRef(null);
+
+  // Keep the editor content theme in sync with the live `theme-variant` cookie: poll
+  // (catches the link-flip activation used where there is no header toggle) and listen
+  // for the header's `rg-theme-variant` broadcast (live toggle in other MFEs).
+  useEffect(() => {
+    const sync = () => applyEditorTheme(editorRef.current);
+    const intervalId = setInterval(sync, 1000);
+    const onMessage = (e) => { if (e && e.data && e.data.type === 'rg-theme-variant') sync(); };
+    window.addEventListener('message', onMessage);
+    return () => { clearInterval(intervalId); window.removeEventListener('message', onMessage); };
+  }, []);
 
   return (
     <Editor
@@ -49,7 +108,11 @@ export default function TextEditor(props) {
       onEditorChange={onChange}
       value={value}
       onKeyUp={onKeyUp}
-      onInit={onInit}
+      onInit={(evt, editor) => {
+        editorRef.current = editor;
+        applyEditorTheme(editor);
+        onInit(evt, editor);
+      }}
       disabled={disabled}
     />
   );


### PR DESCRIPTION
## Description

The bulk email tool's message editor writes into its own embedded frame that
doesn't pick up the platform's dark theme, so in dark mode authors saw black
text on a dark background — effectively unreadable. This change keeps that
editor's writing surface in sync with the user's theme: it turns dark when dark
mode is on and reverts to light when it's off, updating live as the user
toggles, so composing a course email is legible and consistent with the rest of
the interface.

## Youtrack

- https://youtrack.raccoongang.com/issue/ENG-63

## Screenshot/Video

| 1 | 2 | 3 |
|--------|--------|--------|
| <img width="3456" height="6244" alt="image" src="https://github.com/user-attachments/assets/220af0e9-2e75-49ce-ac68-8af25f663da9" /> | <img width="3456" height="1770" alt="image" src="https://github.com/user-attachments/assets/d18a4e12-6d34-4c7f-bbbb-6c607f0f43e5" /> | <img width="3456" height="1770" alt="image" src="https://github.com/user-attachments/assets/46999b22-2cad-4af1-9ad1-ba65b70d992b" /> | 

## Testing

**1. Dark editing surface on open (happy path)**
1. As an instructor/staff member with dark mode enabled (the
   `theme-variant=dark` cookie is set), open the Communications app and start a
   new bulk email.
2. Click into the message body editor.
3. Expected: the editor surface is dark (dark background, light text, green
   links) and the text is clearly readable.

**2. Live toggle, both directions**
1. With the bulk-email editor open, switch the theme to dark (via the header
   toggle in another MFE / the shared header).
2. Expected: the editor surface turns dark within about a second, without
   reopening or reloading.
3. Switch back to light.
4. Expected: the editor surface reverts to the original light surface live.

**3. Activation without a header toggle**
1. On a setup where this MFE has no header toggle, enable dark mode by the
   normal link-based activation (which sets the `theme-variant=dark` cookie).
2. Open the bulk-email editor.
3. Expected: the editor surface is dark (picked up via the cookie poll).

**4. Light mode unchanged**
1. With dark mode off (no `theme-variant` cookie, or set to `light`), open the
   editor.
2. Expected: the editor shows its standard light surface — no visual change.

**5. Element readability in dark**
1. In a dark-mode editor, add links, a blockquote, inline code, a table, and a
   horizontal rule.
2. Expected: every element (link color, quote border, code background, table
   and rule borders) is legible against the dark surface.
